### PR TITLE
Fix the prepend method

### DIFF
--- a/src/data-structures/linked-list/LinkedList.js
+++ b/src/data-structures/linked-list/LinkedList.js
@@ -22,6 +22,7 @@ export default class LinkedList {
   prepend(value) {
     // Make new node to be a head.
     const newNode = new LinkedListNode(value, this.head);
+    newNode.next = this.head;
     this.head = newNode;
 
     // If there is no tail yet let's make new node a tail.


### PR DESCRIPTION
Add the newNode.next reference , so that the new head(newNode) and the old head(this.head before giving new reference value ) will be linked by .next after prepend method.